### PR TITLE
Pass consultation fee to MakePaymentPage and update total fee calcula…

### DIFF
--- a/lib/screens/book_appointment_screen.dart
+++ b/lib/screens/book_appointment_screen.dart
@@ -204,7 +204,9 @@ class _BookAppointmentPageState extends State<BookAppointmentPage> {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => MakePaymentPage(),
+            builder: (context) => MakePaymentPage(
+              consultationFee: consultationFee,
+            ),
           ),
         );
 

--- a/lib/screens/make_payment.dart
+++ b/lib/screens/make_payment.dart
@@ -2,14 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:nuranest/screens/transaction_completed_screen.dart';
 
 class MakePaymentPage extends StatefulWidget {
+  String? consultationFee;
   @override
   _MakePaymentPageState createState() => _MakePaymentPageState();
+
+  MakePaymentPage({Key? key, this.consultationFee}) : super(key: key);
 }
 
 class _MakePaymentPageState extends State<MakePaymentPage> {
   bool isCheckboxChecked = false;
   bool isVisaSelected = false; // Track whether Visa is selected
-  bool isPaymentMethodSelected = false; // Track if any payment method is selected
+  bool isPaymentMethodSelected =
+      false; // Track if any payment method is selected
+  String? consultationFee;
+  int? totalFee;
+
+  @override
+  void initState() {
+    super.initState();
+    consultationFee = widget.consultationFee;
+    calculateTotalFee(consultationFee!, 250.00);
+  }
+
+  void calculateTotalFee(String consultationFee, double taxFee) {
+    int consultationFeeInt = int.tryParse(consultationFee) ?? 0;
+    debugPrint("Consultation Fee: $consultationFeeInt");
+    totalFee = consultationFeeInt + taxFee.toInt();
+    debugPrint("Total Fee: $totalFee");
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,10 +58,10 @@ class _MakePaymentPageState extends State<MakePaymentPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text("Consultation Fee: 5\$"),
-                  Text("Tax Fee: 0.8\$"),
+                  Text("Consultation Fee: Rs. $consultationFee"),
+                  Text("Tax Fee: Rs. 250.00"),
                   Text(
-                    "Total Fee: 5.8\$",
+                    "Total Fee: Rs. $totalFee",
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
                 ],
@@ -67,15 +87,20 @@ class _MakePaymentPageState extends State<MakePaymentPage> {
                   Column(
                     children: [
                       Card(
-                        color: isVisaSelected ? Colors.blue[50] : Colors.white, // Change color when selected
+                        color: isVisaSelected
+                            ? Colors.blue[50]
+                            : Colors.white, // Change color when selected
                         child: ListTile(
-                          leading: Image.asset('lib/assets/images/visa.png', width: 70, height: 70),
+                          leading: Image.asset('lib/assets/images/visa.png',
+                              width: 70, height: 70),
                           title: Text.rich(
                             TextSpan(
                               children: [
                                 TextSpan(
                                   text: "1234 5678 9123 4567\n",
-                                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                                  style: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.bold),
                                 ),
                                 TextSpan(
                                   text: "Example Name\n",
@@ -83,18 +108,24 @@ class _MakePaymentPageState extends State<MakePaymentPage> {
                                 ),
                                 TextSpan(
                                   text: "12/26",
-                                  style: TextStyle(fontSize: 12, fontStyle: FontStyle.italic),
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      fontStyle: FontStyle.italic),
                                 ),
                               ],
                             ),
                           ),
                           trailing: isVisaSelected
-                              ? Icon(Icons.check, color: Colors.green) // Show checkmark when selected
+                              ? Icon(Icons.check,
+                                  color: Colors
+                                      .green) // Show checkmark when selected
                               : null,
                           onTap: () {
                             setState(() {
-                              isVisaSelected = !isVisaSelected; // Toggle the Visa selection
-                              isPaymentMethodSelected = isVisaSelected; // Update the payment method selected status
+                              isVisaSelected =
+                                  !isVisaSelected; // Toggle the Visa selection
+                              isPaymentMethodSelected =
+                                  isVisaSelected; // Update the payment method selected status
                             });
                           },
                         ),
@@ -105,12 +136,15 @@ class _MakePaymentPageState extends State<MakePaymentPage> {
                   Row(
                     children: [
                       Checkbox(
-                        value: isCheckboxChecked && isPaymentMethodSelected, // Disable checkbox if no payment method is selected
-                        onChanged: isPaymentMethodSelected ? (value) {
-                          setState(() {
-                            isCheckboxChecked = value!;
-                          });
-                        } : null, // Only allow checkbox change when a payment method is selected
+                        value: isCheckboxChecked &&
+                            isPaymentMethodSelected, // Disable checkbox if no payment method is selected
+                        onChanged: isPaymentMethodSelected
+                            ? (value) {
+                                setState(() {
+                                  isCheckboxChecked = value!;
+                                });
+                              }
+                            : null, // Only allow checkbox change when a payment method is selected
                       ),
                       Expanded(
                         child: Text(
@@ -123,19 +157,24 @@ class _MakePaymentPageState extends State<MakePaymentPage> {
                   SizedBox(height: 16),
                   // Fade the "Make Payment" button based on both conditions
                   AnimatedOpacity(
-                    opacity: (isCheckboxChecked && isPaymentMethodSelected) ? 1.0 : 0.3,
+                    opacity: (isCheckboxChecked && isPaymentMethodSelected)
+                        ? 1.0
+                        : 0.3,
                     duration: Duration(seconds: 1),
                     child: SizedBox(
                       width: double.infinity,
                       child: ElevatedButton(
-                        onPressed: (isCheckboxChecked && isPaymentMethodSelected)
-                            ? () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(builder: (context) => TransactionCompletedPage()),
-                                );
-                              }
-                            : null,
+                        onPressed:
+                            (isCheckboxChecked && isPaymentMethodSelected)
+                                ? () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                          builder: (context) =>
+                                              TransactionCompletedPage()),
+                                    );
+                                  }
+                                : null,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: Color(0xFFE6CDB7),
                           padding: const EdgeInsets.symmetric(vertical: 16),


### PR DESCRIPTION
This pull request introduces changes to the `MakePaymentPage` to include a consultation fee and calculate the total fee dynamically. The changes affect the `book_appointment_screen.dart` and `make_payment.dart` files. The most important changes include passing the consultation fee to the `MakePaymentPage`, updating the UI to display the fee details, and refactoring code for better readability.

Enhancements to `MakePaymentPage`:

* [`lib/screens/book_appointment_screen.dart`](diffhunk://#diff-86a511e7401f8fdb3e96f1abc610c4d17078733a812cf7ed6a2f10609ea82a8fL207-R209): Modified the `Navigator.push` call to pass the `consultationFee` parameter to the `MakePaymentPage` constructor.
* [`lib/screens/make_payment.dart`](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdR5-R32): Added a `consultationFee` parameter to the `MakePaymentPage` constructor and initialized it in the `initState` method. Implemented a `calculateTotalFee` method to compute the total fee.
* [`lib/screens/make_payment.dart`](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdL41-R64): Updated the UI to display the consultation fee, tax fee, and total fee dynamically based on the passed consultation fee.

Code readability improvements:

* [`lib/screens/make_payment.dart`](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdL70-R128): Refactored the `isVisaSelected` and `isPaymentMethodSelected` logic for better readability.
* [`lib/screens/make_payment.dart`](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdL108-R147): Improved the readability of the `AnimatedOpacity` widget and the `onChanged` callback of the `Checkbox` widget. [[1]](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdL108-R147) [[2]](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdL126-R174)