### PR TITLE
Remove unused imports from various screens for cleaner code

### DIFF
--- a/lib/psychologist_screens/enroll_as_psychologist.dart
+++ b/lib/psychologist_screens/enroll_as_psychologist.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nuranest/psychologist_screens/after_request_profile.dart';
 import 'package:nuranest/utils/storage_helper.dart';
-import 'package:shared_preferences/shared_preferences.dart'; // Import the SharedPreferences library
+// import 'package:shared_preferences/shared_preferences.dart'; // Import the SharedPreferences library
 import 'dart:convert'; // Import for JSON decoding
 import 'package:http/http.dart' as http; // Import the http library
 import 'package:jwt_decoder/jwt_decoder.dart'; // Import the jwt_decoder library

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
-import 'package:nuranest/psychologist_screens/enroll_as_psychologist.dart';
 import 'package:nuranest/psychologist_screens/psychologist_login_screen.dart';
 import 'dart:convert';
 import 'package:nuranest/screens/signup_screen.dart';

--- a/lib/screens/make_payment.dart
+++ b/lib/screens/make_payment.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:nuranest/screens/transaction_completed_screen.dart';
 
 class MakePaymentPage extends StatefulWidget {
-  String? consultationFee;
+  final String? consultationFee;
   @override
   _MakePaymentPageState createState() => _MakePaymentPageState();
 

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:nuranest/psychologist_screens/enroll_as_psychologist.dart';
+// import 'package:nuranest/psychologist_screens/enroll_as_psychologist.dart';
 import 'package:nuranest/screens/get_started_screen.dart';
-import 'package:nuranest/screens/login_screen.dart';
+// import 'package:nuranest/screens/login_screen.dart';
 import 'package:nuranest/screens/payment_details.dart';
 import 'package:nuranest/utils/appointmentValidators.dart';
 import 'package:nuranest/utils/userValidators.dart';

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
-import 'package:nuranest/psychologist_screens/enroll_as_psychologist.dart';
+// import 'package:nuranest/psychologist_screens/enroll_as_psychologist.dart';
 import 'dart:convert';
 
 import 'package:nuranest/screens/login_screen.dart';


### PR DESCRIPTION
This pull request includes several changes to the import statements across multiple files, as well as a modification to a class property in `make_payment.dart`. The most important changes are summarized below:

### Import Statement Modifications:
* [`lib/psychologist_screens/enroll_as_psychologist.dart`](diffhunk://#diff-e381aea868f6eec64877b642b97362c7ddfdefbdde236ca84d05f55cfd0209daL4-R4): Commented out the import of `shared_preferences` library.
* [`lib/screens/login_screen.dart`](diffhunk://#diff-178bdbefc493ff380da5c525b7dc4afd7f7e57260267619f2017e17a617e3a4aL4): Removed the import of `enroll_as_psychologist.dart`.
* [`lib/screens/profile_page.dart`](diffhunk://#diff-b82bd32352b96355330dd5b7f46b9bfd357d69509432724604af5f4ecb4a316fL3-R5): Commented out the imports of `enroll_as_psychologist.dart` and `login_screen.dart`.
* [`lib/screens/signup_screen.dart`](diffhunk://#diff-e5c9a5c312a2c33710db7753c0b79296167b6f99a7b941a3a6b9bc1eec37f82eL4-R4): Commented out the import of `enroll_as_psychologist.dart`.

### Class Property Modification:
* [`lib/screens/make_payment.dart`](diffhunk://#diff-4a09d0a8dea46b667f8addc21793f8c904c89d14bb0892dca9362b5b068e3ccdL5-R5): Changed the `consultationFee` property from a non-final to a final variable.