### PR TITLE
Add setup profile reminder section in psychologist home screen

### DIFF
--- a/lib/psychologist_screens/psychologist_home.dart
+++ b/lib/psychologist_screens/psychologist_home.dart
@@ -70,11 +70,14 @@ class HomeScreenContent extends StatefulWidget {
 class _HomeScreenContentState extends State<HomeScreenContent> {
   String? userName; // Default usernamep
   int? userId; // Default userId
+  bool? isShowSetupProfile =
+      false; // Default value for showing the setup profile reminder
 
   @override
   void initState() {
     super.initState();
     _loadUserName();
+    isShowSetupProfile = false; // Set to false to show the reminder
   }
 
 // Load the user's username from SharedPreferences
@@ -149,13 +152,22 @@ class _HomeScreenContentState extends State<HomeScreenContent> {
             ),
           ),
           const SizedBox(height: 30),
-          _buildReminderCard(context),
-          const SizedBox(height: 20),
+          if (isShowSetupProfile == true) _buildReminderSection(context),
           _buildPsychologistCard(context),
           const SizedBox(height: 20),
           _buildArticlesCard(context),
         ],
       ),
+    );
+  }
+
+  // Widget for the reminder section
+  Widget _buildReminderSection(BuildContext context) {
+    return Column(
+      children: [
+        _buildReminderCard(context),
+        const SizedBox(height: 20),
+      ],
     );
   }
 


### PR DESCRIPTION
This pull request includes changes to the `lib/psychologist_screens/psychologist_home.dart` file to improve the handling and display of the setup profile reminder. The most important changes include adding a new state variable to control the visibility of the reminder, conditionally displaying the reminder section, and refactoring the reminder card into a new widget.

Improvements to handling and display of setup profile reminder:

* [`lib/psychologist_screens/psychologist_home.dart`](diffhunk://#diff-2fbb214659712cf7337641b9416649efef2a111c0e2ff21314e4f863d8437d1fR73-R80): Added a new state variable `isShowSetupProfile` to control the visibility of the setup profile reminder.
* [`lib/psychologist_screens/psychologist_home.dart`](diffhunk://#diff-2fbb214659712cf7337641b9416649efef2a111c0e2ff21314e4f863d8437d1fR73-R80): Updated the `initState` method to set `isShowSetupProfile` to false by default.
* [`lib/psychologist_screens/psychologist_home.dart`](diffhunk://#diff-2fbb214659712cf7337641b9416649efef2a111c0e2ff21314e4f863d8437d1fL152-R155): Conditionally displayed the reminder section based on the value of `isShowSetupProfile`.
* [`lib/psychologist_screens/psychologist_home.dart`](diffhunk://#diff-2fbb214659712cf7337641b9416649efef2a111c0e2ff21314e4f863d8437d1fR164-R173): Added a new widget `_buildReminderSection` to encapsulate the reminder card and its spacing.